### PR TITLE
Python - Adding Strong Typing Emphasis + Unit Test Tools to CR Doc

### DIFF
--- a/Engineering/CodeReviews/Python.md
+++ b/Engineering/CodeReviews/Python.md
@@ -2,7 +2,7 @@
 
 ## Python Style Guide
 
-[CSE](../CSE.md) developers follow [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+[CSE](../CSE.md) developers follow [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html). Note the use of strong typing throughout. Older versions of python allow you to get away without this but type checking avoids common errors that are tricky to debug. 
 
 ## Linters
 

--- a/Engineering/CodeReviews/Python.md
+++ b/Engineering/CodeReviews/Python.md
@@ -24,5 +24,21 @@ We follow the [PEP 257](https://www.python.org/dev/peps/pep-0257/) Docstring con
 
 Flake8 is an option for teams who want a single wrapper for running Pyflakes and pycodestyle.
 
+## Unit Testing
+
+### [```Pytest```](https://docs.pytest.org/en/latest/)
+Pytest is a simple unit testing framework that provides the basics for unit testing: asserts, fixtures, etc... 
+
+```bash
+pip3 install pytest
+```
+
+### [```Pytest-mock```](https://github.com/pytest-dev/pytest-mock/)
+Mocking/stubbing framework that works with Pytest. Use this to mock out OS calls, off-box calls, and other calls that would unnecessarily broaden the scope of unit tests.
+
+```bash
+pip3 install pytest-mock
+```
+
 ## Starter Code Review Checklist
 


### PR DESCRIPTION
Given that Python is typically used for rapid prototyping & development, developers frequently forget to use strong typing. However, strong typing can catch a lot of hard-to-debug errors later on down the line. It's included in the linked style guidelines but it's easy to miss so worth emphasizing.

In addition, unit testing is often overlooked with Python but it's still incredibly important in a multi-engineer / rapid development environment. Added tools that we found useful for mocking & unit testing to the Code Review doc